### PR TITLE
Remove printf in gridshiftpp.h

### DIFF
--- a/github/gridshiftpp.h
+++ b/github/gridshiftpp.h
@@ -155,7 +155,6 @@ void grid_cluster(int n,
             
             if (map_cluster.find(bin) == map_cluster.end()){
                 map_cluster[bin] = temp++;
-                printf("%d\n", temp);
             }
 
             //replace (membershipp.begin(), membershipp.end(), map_cluster_old[current_bin], map_cluster[bin]);


### PR DESCRIPTION
Thank you for your great project.

I suggest that printf be removed for clean output space.

Sometimes running the fit_predict() outputs hundreds of lines, preventing smooth usage.